### PR TITLE
Added PHP DocBlocks, minor cleanup, and example response added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,101 @@ A successful API call responds with the following values:
 * **domain** `string` - The domain of the provided email address. (`bob@example.com` -> `example.com`)
 * **success** `true | false` - *true* if the API request was successful (i.e., no authentication or unexpected errors occurred)
 
+An example response would look like:
+
+```php
+
+$response = $kickbox->verify('test@example.com');
+
+var_dump($response);
+
+//Below is an example of what the var_dump($response) looks like
+
+class Kickbox\HttpClient\Response#29 (3) {
+  public $body =>
+  array(13) {
+    'result' =>
+    string(11) "deliverable"
+    'reason' =>
+    string(14) "accepted_email"
+    'role' =>
+    bool(false)
+    'free' =>
+    bool(true)
+    'disposable' =>
+    bool(false)
+    'accept_all' =>
+    bool(false)
+    'did_you_mean' =>
+    NULL
+    'sendex' =>
+    int(1)
+    'email' =>
+    string(20) "test@example.com"
+    'user' =>
+    string(9) "test"
+    'domain' =>
+    string(10) "example.com"
+    'success' =>
+    bool(true)
+    'message' =>
+    NULL
+  }
+  public $code =>
+  int(200)
+  public $headers =>
+  class Guzzle\Http\Message\Header\HeaderCollection#40 (1) {
+    protected $headers =>
+    array(11) {
+      'server' =>
+      class Guzzle\Http\Message\Header#41 (3) {
+        ...
+      }
+      'date' =>
+      class Guzzle\Http\Message\Header#42 (3) {
+        ...
+      }
+      'content-type' =>
+      class Guzzle\Http\Message\Header#43 (3) {
+        ...
+      }
+      'content-length' =>
+      class Guzzle\Http\Message\Header#44 (3) {
+        ...
+      }
+      'connection' =>
+      class Guzzle\Http\Message\Header#45 (3) {
+        ...
+      }
+      'cache-control' =>
+      class Guzzle\Http\Message\Header\CacheControl#46 (4) {
+        ...
+      }
+      'pragma' =>
+      class Guzzle\Http\Message\Header#47 (3) {
+        ...
+      }
+      'expires' =>
+      class Guzzle\Http\Message\Header#48 (3) {
+        ...
+      }
+      'x-kickbox-balance' =>
+      class Guzzle\Http\Message\Header#49 (3) {
+        ...
+      }
+      'set-cookie' =>
+      class Guzzle\Http\Message\Header#50 (3) {
+        ...
+      }
+      'x-kickbox-response-time' =>
+      class Guzzle\Http\Message\Header#51 (3) {
+        ...
+      }
+    }
+  }
+}
+```
+
 ### Response headers
 
 Along with each response, the following HTTP headers are included:

--- a/README.md
+++ b/README.md
@@ -99,12 +99,10 @@ A successful API call responds with the following values:
 An example response would look like:
 
 ```php
-
 $response = $kickbox->verify('test@example.com');
-
 var_dump($response);
 
-//Below is an example of what the var_dump($response) looks like
+//Below is an example of what the var_dump($response) looks like:
 
 class Kickbox\HttpClient\Response#29 (3) {
   public $body =>

--- a/lib/Kickbox/Api/Kickbox.php
+++ b/lib/Kickbox/Api/Kickbox.php
@@ -4,9 +4,6 @@ namespace Kickbox\Api;
 
 use Kickbox\HttpClient\HttpClient;
 
-/**
- *
- */
 class Kickbox
 {
 

--- a/lib/Kickbox/Api/Kickbox.php
+++ b/lib/Kickbox/Api/Kickbox.php
@@ -10,8 +10,14 @@ use Kickbox\HttpClient\HttpClient;
 class Kickbox
 {
 
+    /**
+     * @var HttpClient
+     */
     private $client;
 
+    /**
+     * @param HttpClient $client
+     */
     public function __construct(HttpClient $client)
     {
         $this->client = $client;
@@ -22,7 +28,8 @@ class Kickbox
      *
      * '/verify?email=:email&timeout=:timeout' GET
      *
-     * @param $email Email address to verify
+     * @param string $email Email address to verify
+     * @return \Kickbox\HttpClient\Response
      */
     public function verify($email, array $options = array())
     {

--- a/lib/Kickbox/Api/Kickbox.php
+++ b/lib/Kickbox/Api/Kickbox.php
@@ -29,6 +29,7 @@ class Kickbox
      * '/verify?email=:email&timeout=:timeout' GET
      *
      * @param string $email Email address to verify
+     * @param array $options
      * @return \Kickbox\HttpClient\Response
      */
     public function verify($email, array $options = array())

--- a/lib/Kickbox/Client.php
+++ b/lib/Kickbox/Client.php
@@ -6,15 +6,22 @@ use Kickbox\HttpClient\HttpClient;
 
 class Client
 {
+    /**
+     * @var HttpClient
+     */
     private $httpClient;
 
+    /**
+     * @param array $auth
+     * @param array $options
+     */
     public function __construct($auth = array(), array $options = array())
     {
         $this->httpClient = new HttpClient($auth, $options);
     }
 
     /**
-     * 
+     * @return Api\Kickbox
      */
     public function kickbox()
     {

--- a/lib/Kickbox/HttpClient/AuthHandler.php
+++ b/lib/Kickbox/HttpClient/AuthHandler.php
@@ -9,10 +9,16 @@ use Guzzle\Common\Event;
  */
 class AuthHandler
 {
+    /**
+     * @var array
+     */
     private $auth;
 
     const HTTP_HEADER = 1;
 
+    /**
+     * @param array $auth
+     */
     public function __construct(array $auth = array())
     {
         $this->auth = $auth;
@@ -31,6 +37,10 @@ class AuthHandler
         return -1;
     }
 
+    /**
+     * @param Event $event
+     * @throws \ErrorException
+     */
     public function onRequestBeforeSend(Event $event)
     {
         if (empty($this->auth)) {
@@ -52,6 +62,8 @@ class AuthHandler
 
     /**
      * Authorization with HTTP header
+     *
+     * @param Event $event
      */
     public function httpHeader(Event $event)
     {

--- a/lib/Kickbox/HttpClient/ErrorHandler.php
+++ b/lib/Kickbox/HttpClient/ErrorHandler.php
@@ -3,18 +3,21 @@
 namespace Kickbox\HttpClient;
 
 use Guzzle\Common\Event;
-use Guzzle\Http\Message\Response;
 
-use Kickbox\HttpClient\ResponseHandler;
 use Kickbox\Exception\ClientException;
 
 /**
- * ErrorHanlder takes care of selecting the error message from response body
+ * ErrorHandler takes care of selecting the error message from response body
  */
 class ErrorHandler
 {
+    /**
+     * @param Event $event
+     * @throws ClientException
+     */
     public function onRequestError(Event $event)
     {
+        /** @var \Guzzle\Http\Message\Request $request */
         $request = $event['request'];
         $response = $request->getResponse();
 

--- a/lib/Kickbox/HttpClient/HttpClient.php
+++ b/lib/Kickbox/HttpClient/HttpClient.php
@@ -3,14 +3,7 @@
 namespace Kickbox\HttpClient;
 
 use Guzzle\Http\Client as GuzzleClient;
-use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Message\RequestInterface;
-
-use Kickbox\HttpClient\AuthHandler;
-use Kickbox\HttpClient\ErrorHandler;
-use Kickbox\HttpClient\RequestHandler;
-use Kickbox\HttpClient\Response;
-use Kickbox\HttpClient\ResponseHandler;
 
 /**
  * Main HttpClient which is used by Api classes
@@ -25,6 +18,10 @@ class HttpClient
 
     protected $headers = array();
 
+    /**
+     * @param array $auth
+     * @param array $options
+     */
     public function __construct($auth = array(), array $options = array())
     {
 
@@ -55,26 +52,61 @@ class HttpClient
         }
     }
 
+    /**
+     * @param string $path
+     * @param array $params
+     * @param array $options
+     * @return \Kickbox\HttpClient\Response
+     * @throws \ErrorException
+     */
     public function get($path, array $params = array(), array $options = array())
     {
         return $this->request($path, null, 'GET', array_merge($options, array('query' => $params)));
     }
 
+    /**
+     * @param string $path
+     * @param \Guzzle\Http\EntityBodyInterface|string $body
+     * @param array $options
+     * @return \Kickbox\HttpClient\Response
+     * @throws \ErrorException
+     */
     public function post($path, $body, array $options = array())
     {
         return $this->request($path, $body, 'POST', $options);
     }
 
+    /**
+     * @param string $path
+     * @param \Guzzle\Http\EntityBodyInterface|string $body
+     * @param array $options
+     * @return \Kickbox\HttpClient\Response
+     * @throws \ErrorException
+     */
     public function patch($path, $body, array $options = array())
     {
         return $this->request($path, $body, 'PATCH', $options);
     }
 
+    /**
+     * @param string $path
+     * @param \Guzzle\Http\EntityBodyInterface|string $body
+     * @param array $options
+     * @return \Kickbox\HttpClient\Response
+     * @throws \ErrorException
+     */
     public function delete($path, $body, array $options = array())
     {
         return $this->request($path, $body, 'DELETE', $options);
     }
 
+    /**
+     * @param string $path
+     * @param \Guzzle\Http\EntityBodyInterface|string $body
+     * @param array $options
+     * @return \Kickbox\HttpClient\Response
+     * @throws \ErrorException
+     */
     public function put($path, $body, array $options = array())
     {
         return $this->request($path, $body, 'PUT', $options);
@@ -86,6 +118,13 @@ class HttpClient
      * - Transforms the body of request into correct format
      * - Creates the requests with give parameters
      * - Returns response body after parsing it into correct format
+     *
+     * @param string $path
+     * @param \Guzzle\Http\EntityBodyInterface|string|null $body
+     * @param string $httpMethod
+     * @param array $options
+     * @return \Kickbox\HttpClient\Response
+     * @throws \ErrorException
      */
     public function request($path, $body = null, $httpMethod = 'GET', array $options = array())
     {
@@ -126,6 +165,13 @@ class HttpClient
      * Creating a request with the given arguments
      *
      * If api_version is set, appends it immediately after host
+     *
+     * @param string $httpMethod
+     * @param string $path
+     * @param \Guzzle\Http\EntityBodyInterface|string|null $body
+     * @param array $headers
+     * @param array $options
+     * @return RequestInterface
      */
     public function createRequest($httpMethod, $path, $body = null, array $headers = array(), array $options = array())
     {
@@ -138,6 +184,9 @@ class HttpClient
 
     /**
      * Get response body in correct format
+     *
+     * @param \Guzzle\Http\Message\Response $response
+     * @return \Guzzle\Http\EntityBodyInterface|string
      */
     public function getBody($response)
     {
@@ -146,6 +195,11 @@ class HttpClient
 
     /**
      * Set request body in correct format
+     *
+     * @param RequestInterface $request
+     * @param \Guzzle\Http\EntityBodyInterface|string $body
+     * @param array $options
+     * @return mixed
      */
     public function setBody(RequestInterface $request, $body, $options)
     {

--- a/lib/Kickbox/HttpClient/HttpClient.php
+++ b/lib/Kickbox/HttpClient/HttpClient.php
@@ -186,7 +186,7 @@ class HttpClient
      * Get response body in correct format
      *
      * @param \Guzzle\Http\Message\Response $response
-     * @return \Guzzle\Http\EntityBodyInterface|string
+     * @return array|\Guzzle\Http\EntityBodyInterface|string
      */
     public function getBody($response)
     {

--- a/lib/Kickbox/HttpClient/RequestHandler.php
+++ b/lib/Kickbox/HttpClient/RequestHandler.php
@@ -9,6 +9,12 @@ use Guzzle\Http\Message\RequestInterface;
  */
 class RequestHandler {
 
+    /**
+     * @param RequestInterface $request
+     * @param \Guzzle\Http\EntityBodyInterface|string $body
+     * @param array $options
+     * @return mixed
+     */
     public static function setBody(RequestInterface $request, $body, $options)
     {
         $type = isset($options['request_type']) ? $options['request_type'] : 'raw';

--- a/lib/Kickbox/HttpClient/Response.php
+++ b/lib/Kickbox/HttpClient/Response.php
@@ -7,7 +7,27 @@ namespace Kickbox\HttpClient;
  */
 class Response
 {
-    function __construct($body, $code, $headers) {
+    /**
+     * @var string|\Guzzle\Http\EntityBodyInterface
+     */
+    public $body;
+
+    /**
+     * @var int
+     */
+    public $code;
+
+    /**
+     * @var array|\Guzzle\Http\Message\Header\HeaderCollection
+     */
+    public $headers;
+
+    /**
+     * @param string|\Guzzle\Http\EntityBodyInterface $body
+     * @param int $code
+     * @param array|\Guzzle\Http\Message\Header\HeaderCollection $headers
+     */
+    public function __construct($body, $code, $headers) {
         $this->body = $body;
         $this->code = $code;
         $this->headers = $headers;

--- a/lib/Kickbox/HttpClient/Response.php
+++ b/lib/Kickbox/HttpClient/Response.php
@@ -8,7 +8,7 @@ namespace Kickbox\HttpClient;
 class Response
 {
     /**
-     * @var string|\Guzzle\Http\EntityBodyInterface
+     * @var array
      */
     public $body;
 
@@ -23,7 +23,7 @@ class Response
     public $headers;
 
     /**
-     * @param string|\Guzzle\Http\EntityBodyInterface $body
+     * @param array|string|\Guzzle\Http\EntityBodyInterface $body
      * @param int $code
      * @param array|\Guzzle\Http\Message\Header\HeaderCollection $headers
      */

--- a/lib/Kickbox/HttpClient/ResponseHandler.php
+++ b/lib/Kickbox/HttpClient/ResponseHandler.php
@@ -9,6 +9,10 @@ use Guzzle\Http\Message\Response as GuzzleResponse;
  */
 class ResponseHandler {
 
+    /**
+     * @param GuzzleResponse $response
+     * @return \Guzzle\Http\EntityBodyInterface|string
+     */
     public static function getBody(GuzzleResponse $response)
     {
         $body = $response->getBody(true);

--- a/lib/Kickbox/HttpClient/ResponseHandler.php
+++ b/lib/Kickbox/HttpClient/ResponseHandler.php
@@ -11,7 +11,7 @@ class ResponseHandler {
 
     /**
      * @param GuzzleResponse $response
-     * @return \Guzzle\Http\EntityBodyInterface|string
+     * @return array|\Guzzle\Http\EntityBodyInterface|string
      */
     public static function getBody(GuzzleResponse $response)
     {


### PR DESCRIPTION
## Docblocks
- I've added docblocks to most methods and variables to specify what is input and returned
- This should help people and IDEs while working
    - I specifically started this change so that my IDE (PhpStorm) could type hint correctly
- This is the majority of what is added in this pull request

## Minor Cleanup
- Removed unused imports ("use" statements above classes)
- Removed docblocks which had nothing in them
- Added member variables to the `Response` class corresponding to what is being set in the constructor

## Example Response
- The readme did not include an example of a response from kickbox-php
- Added so that people don't have to look around the package for what is being returned

## Testing
- I have tested out the package by using it locally to make calls with `$kickbox->verify('test@example.com');`
- Everything has been working with no errors logged or noticed

If there are any questions or concerns please let me know - thanks!