### PR TITLE
Removed url encoding which breaks lookups.

### DIFF
--- a/lib/Kickbox/Api/Kickbox.php
+++ b/lib/Kickbox/Api/Kickbox.php
@@ -26,7 +26,7 @@ class Kickbox implements KickboxInterface
     {
         $body = isset($options['query']) ? $options['query'] : [];
         $timeout = isset($options['timeout']) ? $options['timeout'] : 6000;
-        $body['email'] = rawurlencode($email);
+        $body['email'] = $email;
         $body['timeout'] = $timeout;
 
         return $this->client->get('/v2/verify', $body, $options);


### PR DESCRIPTION
After the guzzle update we started noting the sandbox was breaking.

We had a dig around and checked the API response which was

![1st-choice-spares_ _owen_batman](https://user-images.githubusercontent.com/1094740/27685535-7e20c4d6-5cc6-11e7-9ac3-4d86a9d80c16.jpg)

We noticed the email had some form of url encoding on it, and that the result was "undeliverable" - despite the documentation saying that if you have the email address `deliverable@example.com` on the sandbox it would always pass.

after removing the `rawurlencode` (I assume guzzle can handle this itself) we got the following result.

![1st-choice-spares_ _owen_batman](https://user-images.githubusercontent.com/1094740/27685590-cbc1576e-5cc6-11e7-9931-535499e78ebf.jpg)

This shows it that its now passing.

This is also replicable on the live platform

![1st-choice-spares_ _owen_batman](https://user-images.githubusercontent.com/1094740/27685660-1a36354a-5cc7-11e7-8e3b-a6a135cc8ca2.jpg)

Once removing the rawurlencode and we get

![1st-choice-spares_ _owen_batman](https://user-images.githubusercontent.com/1094740/27685678-27c3004e-5cc7-11e7-9107-5ff25fe32027.jpg)

-- This PR fixes the above issue. 

My worry is that any platforms which updated and got the most recent change will be having ALL of their submissions rejected, so its probably worth getting this fixed asap :D


